### PR TITLE
Fix read-only file system error on Heroku

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
---modules-folder /usr/local/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ RUN apk add --update --no-cache \
 
 # Copy app with gems from former build stage
 COPY --from=Builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=Builder /usr/local/node_modules/ /usr/local/node_modules/
 COPY --from=Builder /app/ /app/
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "3000:3000"
     volumes:
       - ruby-bundle:/usr/local/bundle
-      - node-modules:/usr/local/node_modules
+      - node-modules:/app/node_modules
     command: bin/docker-entrypoint
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "webpack-dev-server": "^3.11.0"
   },
   "scripts": {
-    "lint": "ln -sf /usr/local/node_modules /app/node_modules && /app/node_modules/eslint/bin/eslint.js --ext .js,.jsx app/javascript"
+    "lint": "/app/node_modules/eslint/bin/eslint.js --ext .js,.jsx app/javascript"
   }
 }


### PR DESCRIPTION
This PR fixes an error on Heroku: "EROFS: read-only file system, mkdir '/usr/local/node_modules'"